### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/stackapi/application.py
+++ b/stackapi/application.py
@@ -5,6 +5,7 @@ from flask.ext.autodoc import Autodoc
 from stackapi.stackFactory import AbstractStackFactory
 from stackapi.application_config import get_config
 import httplib as status
+import logging
 
 # APPLICATION definition
 USER_CONFIG = get_config()
@@ -106,20 +107,23 @@ def stack(id):
         try:
             return str(WSSTACKLIST[id])
         except (IndexError, ValueError) as exception:
-            return str(exception), status.INTERNAL_SERVER_ERROR
+            logging.error("Error occurred while processing GET request for stack ID %d: %s", id, exception, exc_info=True)
+            return "An internal error occurred.", status.INTERNAL_SERVER_ERROR
     # Push to stack
     elif request.method == 'POST':
         try:
             WSSTACKLIST[id].push(request.get_data())
             return request.get_data()
         except (IndexError, ValueError) as exception:
-            return str(exception), status.INTERNAL_SERVER_ERROR
+            logging.error("Error occurred while processing POST request for stack ID %d: %s", id, exception, exc_info=True)
+            return "An internal error occurred.", status.INTERNAL_SERVER_ERROR
     # Pop from stack
     elif request.method == 'DELETE':
         try:
             return WSSTACKLIST[id].pop()
         except (IndexError, ValueError) as exception:
-            return str(exception), status.INTERNAL_SERVER_ERROR
+            logging.error("Error occurred while processing DELETE request for stack ID %d: %s", id, exception, exc_info=True)
+            return "An internal error occurred.", status.INTERNAL_SERVER_ERROR
 
 
 @APPLICATION.route('/stack/<int:id>/size', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/403studios/stack-ws/security/code-scanning/1](https://github.com/403studios/stack-ws/security/code-scanning/1)

To fix the issue, we will replace the direct exposure of the exception message (`str(exception)`) with a generic error message for the user. The detailed exception information will be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Import the `logging` module to enable server-side logging of exceptions.
2. Replace the `str(exception)` response with a generic error message, such as "An internal error occurred."
3. Log the exception details using `logging.error()` to capture the stack trace for debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
