### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/stackapi/application.py
+++ b/stackapi/application.py
@@ -157,7 +157,8 @@ def stackPeek(id):
         try:
             return str(WSSTACKLIST[id].peek())
         except (IndexError, ValueError) as exception:
-            return str(exception), status.INTERNAL_SERVER_ERROR
+            logging.error("Error in stackPeek: %s", exception, exc_info=True)
+            return "An internal error has occurred.", status.INTERNAL_SERVER_ERROR
 
 
 @APPLICATION.route('/stack/<int:id>/clear', methods=['DELETE'])
@@ -177,7 +178,8 @@ def stackClear(id):
         try:
             return str(WSSTACKLIST[id].clear())
         except (IndexError, ValueError) as exception:
-            return str(exception), status.INTERNAL_SERVER_ERROR
+            logging.error("Error in stackClear: %s", exception, exc_info=True)
+            return "An internal error has occurred.", status.INTERNAL_SERVER_ERROR
 
 
 @APPLICATION.route('/documentation')


### PR DESCRIPTION
Potential fix for [https://github.com/403studios/stack-ws/security/code-scanning/5](https://github.com/403studios/stack-ws/security/code-scanning/5)

To fix the issue, we should replace the direct exposure of the exception message with a generic error message for the user. The detailed exception information should be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues.

The changes involve:
1. Logging the exception details using the `logging` module.
2. Returning a generic error message (e.g., "An internal error has occurred.") to the user along with the appropriate HTTP status code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
